### PR TITLE
Hotfix/1

### DIFF
--- a/src/context/count-context.tsx
+++ b/src/context/count-context.tsx
@@ -21,7 +21,7 @@ interface Props {
   initial?: number;
 }
 
-export function CountContextProvider({ children, initial = 0 }: Props) {
+export function CountContextProvider({ children, initial = 1 }: Props) {
   const [count, setCount] = useState(initial);
   return (
     <CountContext.Provider value={{ count, setCount }}>

--- a/src/pages/a-page.tsx
+++ b/src/pages/a-page.tsx
@@ -39,7 +39,7 @@ export default function APage() {
       ref={buttonRef}
       onClick={() => setCount(count + 1)}
     >
-      {Math.min(count + 1, 10)}
+      {count}
     </Button>
   );
 }


### PR DESCRIPTION
## 현상
11초가 지나서 a-page의 button text가 10으로 변합니다.

## 원인
counter-context의 초기값이 0부터 시작

## 핫픽스 변경 내용

### before
conter context의 initial 0

### after
conter context의 initial 1