### PR TITLE
Hotfix/2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react-dom": "^18.3.1",
     "react-router": "^7.1.0",
     "tailwind-merge": "^2.5.5",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zustand": "^5.0.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.17)
+      zustand:
+        specifier: ^5.0.2
+        version: 5.0.2(@types/react@18.3.18)(react@18.3.1)
     devDependencies:
       '@eslint/js':
         specifier: ^9.17.0
@@ -633,8 +636,6 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-<<<<<<< HEAD
-=======
   '@probe.gl/env@4.0.9':
     resolution: {integrity: sha512-AOmVMD0/j78mX+k4+qX7ZhE0sY9H+EaJgIO6trik0BwV6VcrwxTGCGFAeuRsIGhETDnye06tkLXccYatYxAYwQ==}
 
@@ -644,7 +645,6 @@ packages:
   '@probe.gl/stats@4.0.9':
     resolution: {integrity: sha512-Q9Xt/sJUQaMsbjRKjOscv2t7wXIymTrOEJ4a3da4FTCn7bkKvcdxdyFAQySCrtPxE+YZ5I5lXpWPgv9BwmpE1g==}
 
->>>>>>> task/6
   '@radix-ui/primitive@1.1.1':
     resolution: {integrity: sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==}
 
@@ -2442,6 +2442,24 @@ packages:
   zstd-codec@0.1.5:
     resolution: {integrity: sha512-v3fyjpK8S/dpY/X5WxqTK3IoCnp/ZOLxn144GZVlNUjtwAchzrVo03h+oMATFhCIiJ5KTr4V3vDQQYz4RU684g==}
 
+  zustand@5.0.2:
+    resolution: {integrity: sha512-8qNdnJVJlHlrKXi50LDqqUNmUbuBjoKLrYQBnoChIbVph7vni+sY+YpvdjXG9YLd/Bxr6scMcR+rm5H3aSqPaw==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -3065,8 +3083,6 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-<<<<<<< HEAD
-=======
   '@probe.gl/env@4.0.9': {}
 
   '@probe.gl/log@4.0.9':
@@ -3075,7 +3091,6 @@ snapshots:
 
   '@probe.gl/stats@4.0.9': {}
 
->>>>>>> task/6
   '@radix-ui/primitive@1.1.1': {}
 
   '@radix-ui/react-collection@1.1.1(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -5549,3 +5564,8 @@ snapshots:
 
   zstd-codec@0.1.5:
     optional: true
+
+  zustand@5.0.2(@types/react@18.3.18)(react@18.3.1):
+    optionalDependencies:
+      '@types/react': 18.3.18
+      react: 18.3.1

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,20 @@
 import { Routes, Route } from "react-router";
 import Layout from "@/components/layout";
 import APage from "./pages/a-page";
-import { CountContextProvider } from "./context/count-context";
 import BPage from "./pages/b-page";
 import CPage from "./pages/c-page";
 import Polygon from "./pages/polygon";
 
 function App() {
   return (
-    <CountContextProvider>
-      <Routes>
-        <Route element={<Layout />}>
-          <Route index element={<APage />} />
-          <Route path="/b" element={<BPage />} />
-          <Route path="/c" element={<CPage />} />
-          <Route path="/polygon" element={<Polygon />} />
-        </Route>
-      </Routes>
-    </CountContextProvider>
+    <Routes>
+      <Route element={<Layout />}>
+        <Route index element={<APage />} />
+        <Route path="/b" element={<BPage />} />
+        <Route path="/c" element={<CPage />} />
+        <Route path="/polygon" element={<Polygon />} />
+      </Route>
+    </Routes>
   );
 }
 

--- a/src/pages/a-page.tsx
+++ b/src/pages/a-page.tsx
@@ -1,9 +1,9 @@
 import { Button } from "@/components/ui/button";
-import { CountContext } from "@/context/count-context";
-import { useContext, useEffect, useRef } from "react";
+import { useCountStore } from "@/store/count";
+import { useEffect, useRef } from "react";
 
 export default function APage() {
-  const { count, setCount } = useContext(CountContext);
+  const { count, setCount } = useCountStore();
   const buttonRef = useRef<HTMLButtonElement | null>(null);
   const countRef = useRef<number>(count);
 

--- a/src/pages/b-page.tsx
+++ b/src/pages/b-page.tsx
@@ -1,8 +1,9 @@
 import { Button } from "@/components/ui/button";
-import { CountContext } from "@/context/count-context";
-import { useContext } from "react";
+
+import { useCountStore } from "@/store/count";
 
 export default function BPage() {
-  const { count } = useContext(CountContext);
+  const { count } = useCountStore();
+
   return <Button className=" w-full">{count === 10 ? 1 : 0}</Button>;
 }

--- a/src/pages/c-page.tsx
+++ b/src/pages/c-page.tsx
@@ -1,9 +1,9 @@
 import { Button } from "@/components/ui/button";
-import { CountContext } from "@/context/count-context";
-import { useContext } from "react";
+
+import { useCountStore } from "@/store/count";
 
 export default function CPage() {
-  const { count } = useContext(CountContext);
+  const { count } = useCountStore();
 
   return <Button className=" w-full">{count === 10 ? 2 : 0}</Button>;
 }

--- a/src/store/count.ts
+++ b/src/store/count.ts
@@ -1,0 +1,12 @@
+import { create } from "zustand";
+
+// Zustand 스토어 정의
+interface CountState {
+  count: number;
+  setCount: (newCount: number) => void;
+}
+
+export const useCountStore = create<CountState>((set) => ({
+  count: 1, // 기본 초기값
+  setCount: (newCount) => set({ count: newCount }),
+}));


### PR DESCRIPTION
## 현상

요구사항과 다르게 리액트 내장 API를 사용하는 문제

## 원인

리액트 내장 API가 아니라 외부 라이브러리로 전역객체를 사용해야 함

## 핫픽스 변경 내용

### before
context API로 count를 관리

### after
zustand로 count를 관리